### PR TITLE
Change code detecting initial # so works with both python2 & 3

### DIFF
--- a/pysos.py
+++ b/pysos.py
@@ -153,7 +153,7 @@ class Dict(dict):
                 offset += len(line) 
                 continue
             
-            if line[0] == 0x23:   # == b'#' does not work because b'#' is an array. 0x23 == b'#'[0]
+            if line.startswith(b'#'):	# skip comments but add to free list
                 if len(line) > 5:
                     self._free_lines.append( (len(line), offset) )
             else:


### PR DESCRIPTION
I'm suggesting a change to use the startswith() method to detect the initial # char on commented lines, as this works with both python 2 & 3 (which I wanted for the project I'm using this in). Thanks for the code, has been useful.