### PR TITLE
Implement setdefault

### DIFF
--- a/pysos.py
+++ b/pysos.py
@@ -287,8 +287,9 @@ class Dict(dict):
         return (key in self._offsets)
     
     def setdefault(self, key, val):
-        # See https://github.com/dagnelies/pysos/issues/3
-        raise UserWarning('Operation not available')
+        if key not in self:
+            self[key] = val
+        return self[key]
         
     def observe(self, callback):
         self._observers.append(callback)


### PR DESCRIPTION
The setdefault function is pretty straightforward and simple in Python.

```
>>> a = {}
>>> a[1] = 2
>>> a
{1: 2}
>>> a.setdefault(3, 4) # now it is set to 4, because it didn't exist before
4
>>> a
{1: 2, 3: 4}
>>> a[3] = 6 # changed to 6
>>> a
{1: 2, 3: 6}
>>> del a[3] # no longer exists (default does not mean that it is always the default value)
>>> a
{1: 2}
>>> a.setdefault(1, 8) # does nothing, since key 1 already exists
2
>>> a
{1: 2}
```