### PR TITLE
Prevent reusing the file format comment

### DIFF
--- a/pysos.py
+++ b/pysos.py
@@ -156,7 +156,7 @@ class Dict(dict):
                 continue
             
             if line.startswith(b'#'):	# skip comments but add to free list
-                if len(line) > 5:
+                if len(line) > 5 and offset > 0:
                     self._free_lines.append( (len(line), offset) )
             else:
                 # let's parse the value as well to be sure the data is ok


### PR DESCRIPTION
The file format header can be reused.

How to reproduce:

```python
import pysos

# Initialize an empty dictionary
my_dict = pysos.Dict("my-test.sos")
del my_dict

# Load the file, assign a short value
my_dict = pysos.Dict("my-test.sos")
my_dict[1] = 2
```

And now the file content is:
```
1	2
#E-DICT v1
```